### PR TITLE
Bugfix: add namespace to android build gradle

### DIFF
--- a/platform_device_id/android/build.gradle
+++ b/platform_device_id/android/build.gradle
@@ -25,6 +25,11 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    // Conditional for compatibility with AGP <4.2.
+    if (project.android.hasProperty("namespace")) {
+        namespace 'com.di1shuai.platform_device_id'
+    }
+    
     compileSdkVersion 34
 
     sourceSets {

--- a/platform_device_id/pubspec.yaml
+++ b/platform_device_id/pubspec.yaml
@@ -1,6 +1,6 @@
 name: platform_device_id_plus
 description: This is upgraded version of platform_device_id
-version: 1.0.6
+version: 1.0.7
 homepage: https://github.com/acmonetwork/platform_device_id_plus
 
 environment:


### PR DESCRIPTION
Closes acmonetwork/platform_device_id_plus#1