### PR TITLE
Fix pod install issue in macos

### DIFF
--- a/platform_device_id/macos/platform_device_id_plus.podspec
+++ b/platform_device_id/macos/platform_device_id_plus.podspec
@@ -3,7 +3,7 @@
 # Run `pod lib lint platform_device_id.podspec' to validate before publishing.
 #
 Pod::Spec.new do |s|
-  s.name             = 'platform_device_id'
+  s.name             = 'platform_device_id_plus'
   s.version          = '0.0.1'
   s.summary          = 'macos for platform_device_id plugin.'
   s.description      = <<-DESC

--- a/platform_device_id/pubspec.yaml
+++ b/platform_device_id/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   platform_device_id_linux: ^1.0.0
   platform_device_id_web: ^1.0.0
   platform_device_id_windows: ^1.0.0
-  device_info_plus: ^10.1.0
+  device_info_plus: ^11.1.1
   android_id: ^0.4.0
 
 dev_dependencies:

--- a/platform_device_id_macos/macos/platform_device_id_plus.podspec
+++ b/platform_device_id_macos/macos/platform_device_id_plus.podspec
@@ -3,7 +3,7 @@
 # Run `pod lib lint platform_device_id.podspec' to validate before publishing.
 #
 Pod::Spec.new do |s|
-  s.name             = 'platform_device_id_macos'
+  s.name             = 'platform_device_id_plus'
   s.version          = '0.0.1'
   s.summary          = 'Flutter macos for platform_device_id plugin.'
   s.description      = <<-DESC


### PR DESCRIPTION
error log

```
 [!] No podspec found for `platform_device_id_plus` in `Flutter/ephemeral/.symlinks/plugins/platform_device_id_plus/macos`
```